### PR TITLE
Changes objects to include a fixate function, which can be called pri…

### DIFF
--- a/PersistentMapAPI/PersistentMapAPI/API/WarServices.cs
+++ b/PersistentMapAPI/PersistentMapAPI/API/WarServices.cs
@@ -16,12 +16,12 @@ namespace PersistentMapAPI {
 
         public StarMap GetStarmap() {
             WebOperationContext.Current.OutgoingResponse.Headers.Add("Access-Control-Allow-Origin", "*");
-            return Helper.LoadCurrentMap();
+            return Helper.LoadCurrentMap().fixate();
         }
 
         public System GetSystem(string name) {
             WebOperationContext.Current.OutgoingResponse.Headers.Add("Access-Control-Allow-Origin", "*");
-            StarMap map = Helper.LoadCurrentMap();
+            StarMap map = Helper.LoadCurrentMap().fixate();
             return map.FindSystemByName(name); ;
         }
 

--- a/PersistentMapAPI/PersistentMapAPI/Objects/StarMap.cs
+++ b/PersistentMapAPI/PersistentMapAPI/Objects/StarMap.cs
@@ -3,7 +3,10 @@ using System.Linq;
 
 namespace PersistentMapAPI {
     public class StarMap {
+
         public List<System> systems = new List<System>();
+
+        public bool hasBeenFixated = false;
 
         public System FindSystemByName(string name) {
             System result = null;
@@ -11,6 +14,14 @@ namespace PersistentMapAPI {
                 result = systems.FirstOrDefault(x => x.name.Equals(name));
             }
             return result;
+        }
+
+        // Call to fixate the object graph, activePlayers and companies will no longer be dynamically calculated after this call is performed
+        public StarMap fixate () {
+            Settings settingsForFixation = Helper.LoadSettings();
+            systems.ForEach(x => { x.fixate(settingsForFixation); });
+            this.hasBeenFixated = true;
+            return this;
         }
     }
 }

--- a/PersistentMapAPI/PersistentMapAPI/Objects/System.cs
+++ b/PersistentMapAPI/PersistentMapAPI/Objects/System.cs
@@ -5,8 +5,14 @@ using System.Linq;
 
 namespace PersistentMapAPI {
     public class System {
+
         public List<FactionControl> controlList;
+
         public string name;
+
+        // Settings used when the object was fixated
+        private Settings settingsForFixation = null;
+
         public int activePlayers {
             get{
                 return GetActivePlayers();
@@ -20,9 +26,15 @@ namespace PersistentMapAPI {
             set { }
         }
 
+        // Call to fixate the object graph, activePlayers and companies will no longer be dynamically calculated after this call is performed
+        public void fixate(Settings settings) {
+            this.settingsForFixation = settings;
+        }
+
         private List<string> GetCompanies() {
+            Settings settings = this.settingsForFixation != null ? this.settingsForFixation : Helper.LoadSettings();
+
             List<string> companies = new List<string>();
-            Settings settings = Helper.LoadSettings();
             Dictionary<string, UserInfo> activeConnections = Holder.connectionStore.Where(x => x.Value.LastDataSend.AddMinutes(settings.MinutesForActive) > DateTime.UtcNow).ToDictionary(p => p.Key, p => p.Value);
             foreach (KeyValuePair<string, UserInfo> info in activeConnections) {
                 if (info.Value.lastSystemFoughtAt.Equals(this.name)) {
@@ -33,8 +45,9 @@ namespace PersistentMapAPI {
         }
 
         private int GetActivePlayers() {
+            Settings settings = this.settingsForFixation != null ? this.settingsForFixation : Helper.LoadSettings();
+
             int players = 0;
-            Settings settings = Helper.LoadSettings();
             Dictionary<string, UserInfo> activeConnections = Holder.connectionStore.Where(x => x.Value.LastDataSend.AddMinutes(settings.MinutesForActive) > DateTime.UtcNow).ToDictionary(p => p.Key, p => p.Value);
             foreach (KeyValuePair<string, UserInfo> info in activeConnections) {
                 if (info.Value.lastSystemFoughtAt.Equals(this.name)) {


### PR DESCRIPTION
…or to serialization or traversal to fix the child objects (activePlayers, companies) at a point in time. This significantly improves the performance of the GetSystem and GetStarmap calls.