### PR TITLE
Concurrency

### DIFF
--- a/PersistentMapAPI/PersistentMapAPI/API/DeprecatedWarServices.cs
+++ b/PersistentMapAPI/PersistentMapAPI/API/DeprecatedWarServices.cs
@@ -19,6 +19,7 @@ namespace PersistentMapAPI.API {
         public abstract string PostSalvageForFaction(List<ShopDefItem> salvage, string Faction);
 
         public System PostMissionResultDeprecated(string employer, string target, string systemName, string mresult) {
+            Logger.Debug("WARNING: Deprecated method invoked: PostMissionResultDeprecated");
             try {
                 return PostMissionResult(new MissionResult((Faction)Enum.Parse(typeof(Faction), employer), (Faction)Enum.Parse(typeof(Faction), target), (BattleTech.MissionResult)Enum.Parse(typeof(BattleTech.MissionResult), mresult), systemName, 5, 0, 0), "UNKNOWN");
 
@@ -29,6 +30,7 @@ namespace PersistentMapAPI.API {
         }
 
         public System PostMissionResultDeprecated2(string employer, string target, string systemName, string mresult, string difficulty) {
+            Logger.Debug("WARNING: Deprecated method invoked: PostMissionResultDeprecated2");
             try {
                 return PostMissionResult(new MissionResult((Faction)Enum.Parse(typeof(Faction), employer), (Faction)Enum.Parse(typeof(Faction), target), (BattleTech.MissionResult)Enum.Parse(typeof(BattleTech.MissionResult), mresult), systemName, int.Parse(difficulty), 0, 0), "UNKNOWN");
 
@@ -39,6 +41,7 @@ namespace PersistentMapAPI.API {
         }
 
         public System PostMissionResultDeprecated3(string employer, string target, string systemName, string mresult, string difficulty, string rep) {
+            Logger.Debug("WARNING: Deprecated method invoked: PostMissionResultDeprecated3");
             try {
                 return PostMissionResult(new MissionResult((Faction)Enum.Parse(typeof(Faction), employer), (Faction)Enum.Parse(typeof(Faction), target), (BattleTech.MissionResult)Enum.Parse(typeof(BattleTech.MissionResult), mresult), systemName, int.Parse(difficulty), int.Parse(rep), 0), "UNKNOWN");
 
@@ -49,6 +52,7 @@ namespace PersistentMapAPI.API {
         }
 
         public System PostMissionResultDepricated4(string employer, string target, string systemName, string mresult, string difficulty, string rep, string planetSupport) {
+            Logger.Debug("WARNING: Deprecated method invoked: PostMissionResultDepricated4");
             try {
                 return PostMissionResult(new MissionResult((Faction)Enum.Parse(typeof(Faction), employer), (Faction)Enum.Parse(typeof(Faction), target), (BattleTech.MissionResult)Enum.Parse(typeof(BattleTech.MissionResult), mresult), systemName, int.Parse(difficulty), int.Parse(rep), int.Parse(planetSupport)), "UNKNOWN");
             } catch (Exception e) {
@@ -58,10 +62,12 @@ namespace PersistentMapAPI.API {
         }
 
         public System PostMissionResultDepricated5(MissionResult mresult) {
+            Logger.Debug("WARNING: Deprecated method invoked: PostMissionResultDepricated5");
             return PostMissionResult(mresult, "UNKNOWN");
         }
 
         public string PostPurchaseForFactionDepricated(string Faction, string ID) {
+            Logger.Debug("WARNING: Deprecated method invoked: PostPurchaseForFactionDepricated");
             Faction realFaction = (Faction)Enum.Parse(typeof(Faction), Faction);
             if (Holder.factionShops != null) {
                 FactionShop shop = Holder.factionShops.FirstOrDefault(x => x.shopOwner == realFaction);

--- a/PersistentMapAPI/PersistentMapAPI/API/DeprecatedWarServices.cs
+++ b/PersistentMapAPI/PersistentMapAPI/API/DeprecatedWarServices.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using BattleTech;
+using PersistentMapAPI.Objects;
 
 namespace PersistentMapAPI.API {
 
@@ -17,6 +18,7 @@ namespace PersistentMapAPI.API {
         public abstract System PostMissionResult(MissionResult mresult, string CompanyName);
         public abstract string PostPurchaseForFaction(List<string> ids, string Faction);
         public abstract string PostSalvageForFaction(List<ShopDefItem> salvage, string Faction);
+        public abstract ServiceDataSnapshot GetServiceDataSnapshot();
 
         public System PostMissionResultDeprecated(string employer, string target, string systemName, string mresult) {
             Logger.Debug("WARNING: Deprecated method invoked: PostMissionResultDeprecated");

--- a/PersistentMapAPI/PersistentMapAPI/API/DeprecatedWarServices.cs
+++ b/PersistentMapAPI/PersistentMapAPI/API/DeprecatedWarServices.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using BattleTech;
+
+namespace PersistentMapAPI.API {
+
+    // Container to hold deprecated methods and keep them out of the main service class.
+    public abstract class DeprecatedWarServices : IWarServices {
+
+        public abstract int GetActivePlayers(string MinutesBack);
+        public abstract List<HistoryResult> GetMissionResults(string MinutesBack, string MaxResults);
+        public abstract List<ShopDefItem> GetShopForFaction(string Faction);
+        public abstract StarMap GetStarmap();
+        public abstract string GetStartupTime();
+        public abstract System GetSystem(string name);
+        public abstract System PostMissionResult(MissionResult mresult, string CompanyName);
+        public abstract string PostPurchaseForFaction(List<string> ids, string Faction);
+        public abstract string PostSalvageForFaction(List<ShopDefItem> salvage, string Faction);
+
+        public System PostMissionResultDeprecated(string employer, string target, string systemName, string mresult) {
+            try {
+                return PostMissionResult(new MissionResult((Faction)Enum.Parse(typeof(Faction), employer), (Faction)Enum.Parse(typeof(Faction), target), (BattleTech.MissionResult)Enum.Parse(typeof(BattleTech.MissionResult), mresult), systemName, 5, 0, 0), "UNKNOWN");
+
+            } catch (Exception e) {
+                Logger.LogError(e);
+                return null;
+            }
+        }
+
+        public System PostMissionResultDeprecated2(string employer, string target, string systemName, string mresult, string difficulty) {
+            try {
+                return PostMissionResult(new MissionResult((Faction)Enum.Parse(typeof(Faction), employer), (Faction)Enum.Parse(typeof(Faction), target), (BattleTech.MissionResult)Enum.Parse(typeof(BattleTech.MissionResult), mresult), systemName, int.Parse(difficulty), 0, 0), "UNKNOWN");
+
+            } catch (Exception e) {
+                Logger.LogError(e);
+                return null;
+            }
+        }
+
+        public System PostMissionResultDeprecated3(string employer, string target, string systemName, string mresult, string difficulty, string rep) {
+            try {
+                return PostMissionResult(new MissionResult((Faction)Enum.Parse(typeof(Faction), employer), (Faction)Enum.Parse(typeof(Faction), target), (BattleTech.MissionResult)Enum.Parse(typeof(BattleTech.MissionResult), mresult), systemName, int.Parse(difficulty), int.Parse(rep), 0), "UNKNOWN");
+
+            } catch (Exception e) {
+                Logger.LogError(e);
+                return null;
+            }
+        }
+
+        public System PostMissionResultDepricated4(string employer, string target, string systemName, string mresult, string difficulty, string rep, string planetSupport) {
+            try {
+                return PostMissionResult(new MissionResult((Faction)Enum.Parse(typeof(Faction), employer), (Faction)Enum.Parse(typeof(Faction), target), (BattleTech.MissionResult)Enum.Parse(typeof(BattleTech.MissionResult), mresult), systemName, int.Parse(difficulty), int.Parse(rep), int.Parse(planetSupport)), "UNKNOWN");
+            } catch (Exception e) {
+                Logger.LogError(e);
+                return null;
+            }
+        }
+
+        public System PostMissionResultDepricated5(MissionResult mresult) {
+            return PostMissionResult(mresult, "UNKNOWN");
+        }
+
+        public string PostPurchaseForFactionDepricated(string Faction, string ID) {
+            Faction realFaction = (Faction)Enum.Parse(typeof(Faction), Faction);
+            if (Holder.factionShops != null) {
+                FactionShop shop = Holder.factionShops.FirstOrDefault(x => x.shopOwner == realFaction);
+                if (shop != null) {
+                    ShopDefItem item = shop.currentSoldItems.FirstOrDefault(x => x.ID.Equals(ID));
+                    if (item != null) {
+                        item.Count--;
+                    }
+                    shop.currentSoldItems.RemoveAll(x => x.Count <= 0);
+                }
+            }
+            Logger.Debug(ID + " 1 removed from shop for " + Faction);
+            return ID + " 1 removed from shop for " + Faction;
+        }
+
+    }
+}

--- a/PersistentMapAPI/PersistentMapAPI/API/IWarServices.cs
+++ b/PersistentMapAPI/PersistentMapAPI/API/IWarServices.cs
@@ -1,4 +1,5 @@
 ﻿using BattleTech;
+using PersistentMapAPI.Objects;
 using System.Collections.Generic;
 using System.ServiceModel;
 using System.ServiceModel.Web;
@@ -42,6 +43,10 @@ namespace PersistentMapAPI {
         [OperationContract]
         [WebGet(UriTemplate = Routing.GetShopForFaction, BodyStyle = WebMessageBodyStyle.Bare, ResponseFormat = WebMessageFormat.Json)]
         List<ShopDefItem> GetShopForFaction(string Faction);
+
+        [OperationContract]
+        [WebGet(UriTemplate = Routing.GetServiceDataSnapshot, BodyStyle = WebMessageBodyStyle.Bare, ResponseFormat = WebMessageFormat.Json)]
+        ServiceDataSnapshot GetServiceDataSnapshot();
 
         //DEPRECATED
         [OperationContract]

--- a/PersistentMapAPI/PersistentMapAPI/API/Routing.cs
+++ b/PersistentMapAPI/PersistentMapAPI/API/Routing.cs
@@ -10,6 +10,7 @@
         public const string PostMissionResult = "/Mission/?CompanyName={CompanyName}";
         public const string PostSalvageForFaction = "/Salvage/{Faction}";
         public const string PostPurchaseForFaction = "/Buy/{Faction}";
+        public const string GetServiceDataSnapshot = "/Admin/ServiceDataSnapshot";
 
         //DEPRECATED
         public const string PostPurchaseForFactionDepricated = "/Buy/?Faction={Faction}&ID={ID}";

--- a/PersistentMapAPI/PersistentMapAPI/API/WarServices.cs
+++ b/PersistentMapAPI/PersistentMapAPI/API/WarServices.cs
@@ -1,5 +1,4 @@
 ﻿using BattleTech;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -10,187 +9,150 @@ using System.ServiceModel.Web;
 
 namespace PersistentMapAPI {
 
-    [ServiceBehavior(InstanceContextMode = InstanceContextMode.Single, ConcurrencyMode = ConcurrencyMode.Single, IncludeExceptionDetailInFaults = true)]
+    // Implementation of the current service methods used 
+    [ServiceBehavior(InstanceContextMode = InstanceContextMode.Single, ConcurrencyMode = ConcurrencyMode.Multiple, IncludeExceptionDetailInFaults = true)]
     [AspNetCompatibilityRequirements(RequirementsMode = AspNetCompatibilityRequirementsMode.Allowed)]
-    public class WarServices : IWarServices {
+    public class WarServices : API.DeprecatedWarServices {
 
-        public StarMap GetStarmap() {
+        // Locks to prevent concurrent modification
+        private readonly object _missionResultLock = new Object();
+        private readonly object _salvageLock = new Object();
+        private readonly object _purchaseLock = new Object();
+
+        // Thread-safe; returns copy of starmap. We clone to prevent modification during serialization (due to heavy nesting).
+        public override StarMap GetStarmap() {
             WebOperationContext.Current.OutgoingResponse.Headers.Add("Access-Control-Allow-Origin", "*");
-            return Helper.LoadCurrentMap();
+            return (StarMap)Helper.LoadCurrentMap().Clone();
         }
 
-        public System GetSystem(string name) {
+        // Thread-safe; returns copy of starmap. We clone to prevent modification during serialization (due to heavy nesting).
+        public override System GetSystem(string name) {
             WebOperationContext.Current.OutgoingResponse.Headers.Add("Access-Control-Allow-Origin", "*");
-            StarMap map = Helper.LoadCurrentMap();
+            StarMap map = (StarMap)Helper.LoadCurrentMap().Clone();
             return map.FindSystemByName(name); ;
         }
 
-        public string ResetStarMap() {
-            Logger.LogLine("Init new Map");
-            StarMap map = Helper.initializeNewMap();
-            Holder.currentMap = map;
-            Console.WriteLine("Save new Map");
-            Helper.SaveCurrentMap(map);
-            Console.WriteLine("Map reset Sucessfull");
-            return "Reset Sucessfull";
-        }
+        public override System PostMissionResult(MissionResult mresult, string companyName) {
+            lock (_missionResultLock) {
+                try {
+                    int realDifficulty = Math.Min(10, mresult.difficulty);
+                    string ip = Helper.GetIP();
+                    int realPlanets = Math.Min(Helper.LoadSettings().MaxPlanetSupport, mresult.planetSupport);
+                    int realRep = Math.Min(Helper.LoadSettings().MaxRep, mresult.awardedRep);
+                    if ((Helper.LoadSettings().HalfSkullPercentageForWin * realDifficulty) + realRep + realPlanets > 50) {
+                        Logger.LogToFile("Weird Result - Difficulty: " + realDifficulty + " - planet: " + realPlanets + " - rep: " + realRep + " - employer: " + mresult.employer + " - target: " + mresult.target + " - systemName: " + mresult.systemName + " - mresult: " + mresult.result + " - IP: " + ip);
+                    }
+                    HistoryResult hresult = new HistoryResult();
+                    hresult.date = DateTime.UtcNow;
 
-        public System PostMissionResultDeprecated(string employer, string target, string systemName, string mresult) {
-            try {
-                return PostMissionResult(new MissionResult((Faction)Enum.Parse(typeof(Faction), employer), (Faction)Enum.Parse(typeof(Faction), target), (BattleTech.MissionResult)Enum.Parse(typeof(BattleTech.MissionResult), mresult), systemName, 5, 0, 0), "UNKNOWN");
+                    if (Helper.CheckUserInfo(ip, mresult.systemName, companyName)) {
+                        Logger.LogToFile("One ip trys to send Missions to fast. IP:" + ip);
+                        // TODO: Change response type to make it clear throttling was the issue?
+                        // TODO: Move to pre-processor
+                        return null;
+                    }
+                    Logger.LogLine("New Result Posted");
+                    Logger.Debug("employer: " + mresult.employer);
+                    Logger.Debug("target: " + mresult.target);
+                    Logger.Debug("systemName: " + mresult.systemName);
+                    Logger.Debug("mresult: " + mresult.result);
+                    StarMap map = Helper.LoadCurrentMap();
+                    System system = map.FindSystemByName(mresult.systemName);
+                    FactionControl oldOwnerControl = system.FindHighestControl();
+                    Faction oldOwner = Faction.INVALID_UNSET;
+                    if (oldOwnerControl != null) {
+                        oldOwner = oldOwnerControl.faction;
+                    }
+                    FactionControl employerControl = system.FindFactionControlByFaction(mresult.employer);
+                    FactionControl targetControl = system.FindFactionControlByFaction(mresult.target);
 
-            }
-            catch (Exception e) {
-                Logger.LogError(e);
-                return null;
-            }
-        }
-
-        public System PostMissionResultDeprecated2(string employer, string target, string systemName, string mresult, string difficulty) {
-            try {
-                return PostMissionResult(new MissionResult((Faction)Enum.Parse(typeof(Faction), employer), (Faction)Enum.Parse(typeof(Faction), target), (BattleTech.MissionResult)Enum.Parse(typeof(BattleTech.MissionResult), mresult), systemName, int.Parse(difficulty), 0, 0), "UNKNOWN");
-
-            }
-            catch (Exception e) {
-                Logger.LogError(e);
-                return null;
-            }
-        }
-
-        public System PostMissionResultDeprecated3(string employer, string target, string systemName, string mresult, string difficulty, string rep) {
-            try {
-                return PostMissionResult(new MissionResult((Faction)Enum.Parse(typeof(Faction), employer), (Faction)Enum.Parse(typeof(Faction), target), (BattleTech.MissionResult)Enum.Parse(typeof(BattleTech.MissionResult), mresult), systemName, int.Parse(difficulty), int.Parse(rep), 0), "UNKNOWN");
-
-            }
-            catch (Exception e) {
-                Logger.LogError(e);
-                return null;
-            }
-        }
-
-        public System PostMissionResultDepricated4(string employer, string target, string systemName, string mresult, string difficulty, string rep, string planetSupport) {
-            try {
-                return PostMissionResult(new MissionResult((Faction)Enum.Parse(typeof(Faction), employer), (Faction)Enum.Parse(typeof(Faction), target), (BattleTech.MissionResult)Enum.Parse(typeof(BattleTech.MissionResult), mresult), systemName, int.Parse(difficulty), int.Parse(rep), int.Parse(planetSupport)), "UNKNOWN");
-            }
-            catch (Exception e) {
-                Logger.LogError(e);
-                return null;
-            }
-        }
-
-        public System PostMissionResultDepricated5(MissionResult mresult) {
-            return PostMissionResult(mresult, "UNKNOWN");
-        }
-
-        public System PostMissionResult(MissionResult mresult, string companyName) {
-            try {
-                int realDifficulty = Math.Min(10, mresult.difficulty);
-                string ip = Helper.GetIP();
-                int realPlanets = Math.Min(Helper.LoadSettings().MaxPlanetSupport, mresult.planetSupport);
-                int realRep = Math.Min(Helper.LoadSettings().MaxRep, mresult.awardedRep);
-                if ((Helper.LoadSettings().HalfSkullPercentageForWin * realDifficulty) + realRep + realPlanets > 50){
-                    Logger.LogToFile("Weird Result - Difficulty: " + realDifficulty + " - planet: " + realPlanets + " - rep: " + realRep + " - employer: " + mresult.employer + " - target: " + mresult.target + " - systemName: " + mresult.systemName + " - mresult: " + mresult.result + " - IP: "+ip);
-                }
-                HistoryResult hresult = new HistoryResult();
-                hresult.date = DateTime.UtcNow;
-                
-                if (Helper.CheckUserInfo(ip, mresult.systemName, companyName)) {
-                    Logger.LogToFile("One ip trys to send Missions to fast. IP:" + ip);
+                    if (mresult.result == BattleTech.MissionResult.Victory) {
+                        Logger.Debug("Victory Result");
+                        int realChange = Math.Min(Math.Abs(employerControl.percentage - 100), Math.Max(1, (Helper.LoadSettings().HalfSkullPercentageForWin * realDifficulty) + realRep + realPlanets));
+                        hresult.winner = employerControl.faction;
+                        hresult.loser = targetControl.faction;
+                        hresult.pointsTraded = realChange;
+                        employerControl.percentage += realChange;
+                        targetControl.percentage -= realChange;
+                        Logger.Debug(realChange + " Points traded");
+                        if (targetControl.percentage < 0) {
+                            int leftoverChange = Math.Abs(targetControl.percentage);
+                            Logger.Debug(leftoverChange + " Leftover Points");
+                            targetControl.percentage = 0;
+                            int debugcounter = leftoverChange;
+                            while (leftoverChange > 0 && debugcounter != 0) {
+                                foreach (FactionControl leftOverFaction in system.controlList) {
+                                    if (leftOverFaction.faction != mresult.employer &&
+                                        leftOverFaction.faction != mresult.target && leftOverFaction.percentage > 0
+                                        && leftoverChange > 0) {
+                                        leftOverFaction.percentage--;
+                                        leftoverChange--;
+                                        Logger.Debug(leftOverFaction.faction.ToString() + " Points deducted");
+                                    }
+                                }
+                                debugcounter--;
+                            }
+                        }
+                    } else {
+                        Logger.Debug("Loss Result");
+                        int realChange = Math.Min(employerControl.percentage, Math.Max(1, (Helper.LoadSettings().HalfSkullPercentageForLoss * realDifficulty) + realRep / 2 + realPlanets / 2));
+                        hresult.winner = targetControl.faction;
+                        hresult.loser = employerControl.faction;
+                        hresult.pointsTraded = realChange;
+                        employerControl.percentage -= realChange;
+                        targetControl.percentage += realChange;
+                        Logger.Debug(realChange + " Points traded");
+                    }
+                    FactionControl afterBattleOwnerControl = system.FindHighestControl();
+                    Faction newOwner = afterBattleOwnerControl.faction;
+                    if (oldOwner != newOwner) {
+                        hresult.planetSwitched = true;
+                    } else {
+                        hresult.planetSwitched = false;
+                    }
+                    hresult.system = mresult.systemName;
+                    Holder.resultHistory.Add(hresult);
+                    return system;
+                } catch (Exception e) {
+                    Logger.LogError(e);
                     return null;
                 }
-                Logger.LogLine("New Result Posted");
-                Logger.Debug("employer: " + mresult.employer);
-                Logger.Debug("target: " + mresult.target);
-                Logger.Debug("systemName: " + mresult.systemName);
-                Logger.Debug("mresult: " + mresult.result);
-                StarMap map = Helper.LoadCurrentMap();
-                System system = map.FindSystemByName(mresult.systemName);
-                FactionControl oldOwnerControl = system.FindHighestControl();
-                Faction oldOwner = Faction.INVALID_UNSET;
-                if (oldOwnerControl != null) {
-                    oldOwner = oldOwnerControl.faction;
-                }
-                FactionControl employerControl = system.FindFactionControlByFaction(mresult.employer);
-                FactionControl targetControl = system.FindFactionControlByFaction(mresult.target);
-
-                if (mresult.result == BattleTech.MissionResult.Victory) {
-                    Logger.Debug("Victory Result");
-                    int realChange = Math.Min(Math.Abs(employerControl.percentage - 100), Math.Max(1, (Helper.LoadSettings().HalfSkullPercentageForWin * realDifficulty) + realRep + realPlanets));
-                    hresult.winner = employerControl.faction;
-                    hresult.loser = targetControl.faction;
-                    hresult.pointsTraded = realChange;
-                    employerControl.percentage += realChange;
-                    targetControl.percentage -= realChange;
-                    Logger.Debug(realChange + " Points traded");
-                    if (targetControl.percentage < 0) {
-                        int leftoverChange = Math.Abs(targetControl.percentage);
-                        Logger.Debug(leftoverChange + " Leftover Points");
-                        targetControl.percentage = 0;
-                        int debugcounter = leftoverChange;
-                        while (leftoverChange > 0 && debugcounter != 0) {
-                            foreach (FactionControl leftOverFaction in system.controlList) {
-                                if (leftOverFaction.faction != mresult.employer &&
-                                    leftOverFaction.faction != mresult.target && leftOverFaction.percentage > 0
-                                    && leftoverChange > 0) {
-                                    leftOverFaction.percentage--;
-                                    leftoverChange--;
-                                    Logger.Debug(leftOverFaction.faction.ToString() + " Points deducted");
-                                }
-                            }
-                            debugcounter--;
-                        }
-                    }
-                }
-                else {
-                    Logger.Debug("Loss Result");
-                    int realChange = Math.Min(employerControl.percentage, Math.Max(1, (Helper.LoadSettings().HalfSkullPercentageForLoss * realDifficulty) + realRep / 2 + realPlanets / 2));
-                    hresult.winner = targetControl.faction;
-                    hresult.loser = employerControl.faction;
-                    hresult.pointsTraded = realChange;
-                    employerControl.percentage -= realChange;
-                    targetControl.percentage += realChange;
-                    Logger.Debug(realChange + " Points traded");
-                }
-                FactionControl afterBattleOwnerControl = system.FindHighestControl();
-                Faction newOwner = afterBattleOwnerControl.faction;
-                if (oldOwner != newOwner) {
-                    hresult.planetSwitched = true;
-                }
-                else {
-                    hresult.planetSwitched = false;
-                }
-                hresult.system = mresult.systemName;
-                Holder.resultHistory.Add(hresult);
-                return system;
-            }
-            catch (Exception e) {
-                Logger.LogError(e);
-                return null;
             }
         }
 
-        public List<HistoryResult> GetMissionResults(string MinutesBack, string MaxResults) {
+        // Thread-safe; returns copy of list
+        // TODO: Test with large # of results
+        public override List<HistoryResult> GetMissionResults(string MinutesBack, string MaxResults) {
             WebOperationContext.Current.OutgoingResponse.Headers.Add("Access-Control-Allow-Origin", "*");
-            List<HistoryResult> resultList = Holder.resultHistory.Where(i => i.date.Value.AddMinutes(int.Parse(MinutesBack)) > DateTime.UtcNow).OrderByDescending(x => x.date).Take(int.Parse(MaxResults)).ToList();
+            List<HistoryResult> resultList = Holder.resultHistory
+                .Where(i => i.date.Value.AddMinutes(int.Parse(MinutesBack)) > DateTime.UtcNow)
+                .OrderByDescending(x => x.date)
+                .Take(int.Parse(MaxResults))
+                .ToList();
             return resultList;
         }
 
-        public int GetActivePlayers(string MinutesBack) {
+        // Thread-safe; returns count only
+        // TODO: Test with large # of 
+        public override int GetActivePlayers(string MinutesBack) {
             WebOperationContext.Current.OutgoingResponse.Headers.Add("Access-Control-Allow-Origin", "*");
-            return Holder.connectionStore.Where(x => x.Value.LastDataSend.AddMinutes(int.Parse(MinutesBack)) > DateTime.UtcNow).Count();
+            return Holder.connectionStore
+                .Where(x => x.Value.LastDataSend.AddMinutes(int.Parse(MinutesBack)) > DateTime.UtcNow)
+                .Count();
         }
 
-        public string GetStartupTime() {
+        // Thread-safe; returns simple value.
+        public override string GetStartupTime() {
             WebOperationContext.Current.OutgoingResponse.Headers.Add("Access-Control-Allow-Origin", "*");
             return Holder.startupTime.ToString("o", CultureInfo.InvariantCulture);
         }
 
-        public List<ShopDefItem> GetShopForFaction(string Faction) {
+        public override List<ShopDefItem> GetShopForFaction(string Faction) {
             try {
                 Faction realFaction = (Faction)Enum.Parse(typeof(Faction), Faction);
                 if (Holder.factionShops == null) {
                     Holder.factionShops = new List<FactionShop>();
-                    Logger.LogLine("Shops initilaized");
+                    Logger.LogLine("Shops initialized");
                 }
                 if (Holder.factionShops.FirstOrDefault(x => x.shopOwner == realFaction) == null) {
                     Holder.factionShops.Add(new FactionShop(realFaction, new List<ShopDefItem>(), DateTime.MinValue));
@@ -211,66 +173,64 @@ namespace PersistentMapAPI {
             }
         }
 
-        public string PostSalvageForFaction(List<ShopDefItem> salvage, string Faction) {
-            Faction realFaction = (Faction)Enum.Parse(typeof(Faction), Faction);
-            if (Holder.factionInventories == null) {
-                Helper.LoadCurrentInventories();
-            }
-            if (!Holder.factionInventories.ContainsKey(realFaction)) {
-                Holder.factionInventories.Add(realFaction, new List<ShopDefItem>());
-            }
-            foreach (ShopDefItem item in salvage) {
-                if (Holder.factionInventories[realFaction].FirstOrDefault(x => x.ID.Equals(item.ID)) == null) {
-                    Holder.factionInventories[realFaction].Add(item);
-                }
-                else {
-                    int index = Holder.factionInventories[realFaction].FindIndex(x => x.ID.Equals(item.ID));
-                    Holder.factionInventories[realFaction][index].Count++;
-                    Holder.factionInventories[realFaction][index].DiscountModifier = Math.Max(Holder.factionInventories[realFaction][index].DiscountModifier - Helper.LoadSettings().DiscountPerItem, Helper.LoadSettings().DiscountFloor);                  
-                }
-            }
-            Logger.LogLine(salvage.Count + " items inserted into inventory for " + Faction);
-            return salvage.Count + " items inserted into inventory for " + Faction;
-        }
-
-        public string PostPurchaseForFactionDepricated(string Faction, string ID) {
-            Faction realFaction = (Faction)Enum.Parse(typeof(Faction), Faction);
-            if (Holder.factionShops != null) {
-                FactionShop shop = Holder.factionShops.FirstOrDefault(x => x.shopOwner == realFaction);
-                if (shop != null) {
-                    ShopDefItem item = shop.currentSoldItems.FirstOrDefault(x => x.ID.Equals(ID));
-                    if (item != null) {
-                        item.Count--;
-                    }
-                    shop.currentSoldItems.RemoveAll(x => x.Count <= 0);
-                }
-            }
-            Logger.Debug(ID + " 1 removed from shop for " + Faction);
-            return ID + " 1 removed from shop for " + Faction;
-        }
-
-        public string PostPurchaseForFaction(List<string> ids, string Faction) {
-            try {
+        public override string PostSalvageForFaction(List<ShopDefItem> salvage, string Faction) {
+            lock(_salvageLock) {
                 Faction realFaction = (Faction)Enum.Parse(typeof(Faction), Faction);
-                if (Holder.factionShops != null) {
-                    FactionShop shop = Holder.factionShops.FirstOrDefault(x => x.shopOwner == realFaction);
-                    if (shop != null) {
-                        foreach (string ID in ids) {
-                            ShopDefItem item = shop.currentSoldItems.FirstOrDefault(x => x.ID.Equals(ID));
-                            if (item != null) {
-                                item.Count--;
-                            }
-                        }
-                        shop.currentSoldItems.RemoveAll(x => x.Count <= 0);
+                if (Holder.factionInventories == null) {
+                    Helper.LoadCurrentInventories();
+                }
+                if (!Holder.factionInventories.ContainsKey(realFaction)) {
+                    Holder.factionInventories.Add(realFaction, new List<ShopDefItem>());
+                }
+                foreach (ShopDefItem item in salvage) {
+                    if (Holder.factionInventories[realFaction].FirstOrDefault(x => x.ID.Equals(item.ID)) == null) {
+                        Holder.factionInventories[realFaction].Add(item);
+                    } else {
+                        int index = Holder.factionInventories[realFaction].FindIndex(x => x.ID.Equals(item.ID));
+                        Holder.factionInventories[realFaction][index].Count++;
+                        Holder.factionInventories[realFaction][index].DiscountModifier = Math.Max(Holder.factionInventories[realFaction][index].DiscountModifier - Helper.LoadSettings().DiscountPerItem, Helper.LoadSettings().DiscountFloor);
                     }
                 }
-                Logger.LogLine(ids.Count + " items removed from shop for " + Faction);
-                return ids.Count + " items removed from shop for " + Faction;
-            }
-            catch (Exception e) {
-                Logger.LogError(e);
-                return "Error";
+                Logger.LogLine(salvage.Count + " items inserted into inventory for " + Faction);
+                return salvage.Count + " items inserted into inventory for " + Faction;
             }
         }
+
+        public override string PostPurchaseForFaction(List<string> ids, string Faction) {
+            lock(_purchaseLock) {
+                try {
+                    Faction realFaction = (Faction)Enum.Parse(typeof(Faction), Faction);
+                    if (Holder.factionShops != null) {
+                        FactionShop shop = Holder.factionShops.FirstOrDefault(x => x.shopOwner == realFaction);
+                        if (shop != null) {
+                            foreach (string ID in ids) {
+                                ShopDefItem item = shop.currentSoldItems.FirstOrDefault(x => x.ID.Equals(ID));
+                                if (item != null) {
+                                    item.Count--;
+                                }
+                            }
+                            shop.currentSoldItems.RemoveAll(x => x.Count <= 0);
+                        }
+                    }
+                    Logger.LogLine(ids.Count + " items removed from shop for " + Faction);
+                    return ids.Count + " items removed from shop for " + Faction;
+                } catch (Exception e) {
+                    Logger.LogError(e);
+                    return "Error";
+                }
+            }
+        }
+
+        // NON-SERVICE METHODS BELOW
+        public string ResetStarMap() {
+            Logger.LogLine("Init new Map");
+            StarMap map = Helper.initializeNewMap();
+            Holder.currentMap = map;
+            Console.WriteLine("Save new Map");
+            Helper.SaveCurrentMap(map);
+            Console.WriteLine("Map reset Sucessfull");
+            return "Reset Sucessfull";
+        }
+
     }
 }

--- a/PersistentMapAPI/PersistentMapAPI/API/WarServices.cs
+++ b/PersistentMapAPI/PersistentMapAPI/API/WarServices.cs
@@ -1,4 +1,5 @@
 ﻿using BattleTech;
+using PersistentMapAPI.Objects;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -219,6 +220,13 @@ namespace PersistentMapAPI {
                     return "Error";
                 }
             }
+        }
+
+        // Helper method to return data on current data sizes. Intended to help determine if some objects are growing out of bounds.
+        public override ServiceDataSnapshot GetServiceDataSnapshot() {
+            ServiceDataSnapshot snapshot = new ServiceDataSnapshot();
+
+            return snapshot;
         }
 
         // NON-SERVICE METHODS BELOW

--- a/PersistentMapAPI/PersistentMapAPI/Objects/FactionShop.cs
+++ b/PersistentMapAPI/PersistentMapAPI/Objects/FactionShop.cs
@@ -1,12 +1,13 @@
 ﻿using BattleTech;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace PersistentMapAPI {
+    // Contains all of the items currently available for sale unique to a specific faction.
     public class FactionShop {
+
         public Faction shopOwner;
+        // Items currently for sale
         public List<ShopDefItem> currentSoldItems;
         public DateTime lastUpdate;
 

--- a/PersistentMapAPI/PersistentMapAPI/Objects/ServiceDataSnapshot.cs
+++ b/PersistentMapAPI/PersistentMapAPI/Objects/ServiceDataSnapshot.cs
@@ -67,6 +67,7 @@ namespace PersistentMapAPI.Objects {
             string json_faction_shops = fastJSON.JSON.ToJSON(faction_shop_size);
 
             string toString =
+                "  --- ServerDataSnapshot --- " + Environment.NewLine +
                 $"  Connections: active({num_connections_active}) inactive:({num_connections_inactive}) percent active:({percent_connections_active})" + Environment.NewLine +
                 $"  ResultsHistory: count:({num_results}) before_inactivity:({num_results_past_inactive_time})" + Environment.NewLine +
                 $"  Faction inventory size: {json_inventory_size}" + Environment.NewLine +

--- a/PersistentMapAPI/PersistentMapAPI/Objects/ServiceDataSnapshot.cs
+++ b/PersistentMapAPI/PersistentMapAPI/Objects/ServiceDataSnapshot.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace PersistentMapAPI.Objects {
+    // Point in time overview of the size of internal data elements
+    public class ServiceDataSnapshot {
+
+        public int num_connections_active = 0;
+        public int num_connections_inactive = 0;
+        public float percent_connections_active = 0.0f;
+            
+        public int size_resultHistory = 0;
+        public int size_factionInventory = 0;
+        public int size_factionShopsInventory = 0;
+
+        public ServiceDataSnapshot() {
+            Settings settings = Helper.LoadSettings();
+
+            DateTime activeOnOrAfter = DateTime.UtcNow.Subtract(TimeSpan.FromMinutes(settings.MinutesForActive));
+            int size_connectionStore = Holder.connectionStore.Count;
+            num_connections_active = Holder.connectionStore
+                .Where(x => x.Value.LastDataSend >= activeOnOrAfter)
+                .Count();
+            num_connections_inactive = size_connectionStore - num_connections_active;
+            percent_connections_active = size_connectionStore == 0 ? 
+                0.0f : (size_connectionStore - num_connections_inactive) / (size_connectionStore);
+
+            size_resultHistory = Holder.resultHistory.Count;
+
+        }
+    }
+
+    /*
+     *         // The current state of the map
+        public static StarMap currentMap;
+
+        // List of all connections currently tracked
+        public static Dictionary<string, UserInfo> connectionStore = new Dictionary<string, UserInfo>();
+
+        // All results that have been posted
+        public static List<HistoryResult> resultHistory = new List<HistoryResult>();
+        
+        // When the web-service started
+        public static DateTime startupTime = DateTime.UtcNow;
+
+        // All of the player contributed items available to a faction
+        public static Dictionary<Faction, List<ShopDefItem>> factionInventories;
+
+        // All of the items a faction has for sale
+        public static List<FactionShop> factionShops;
+
+        // When the last backup occurred
+        public static DateTime lastBackup = DateTime.MinValue;
+        */
+}

--- a/PersistentMapAPI/PersistentMapAPI/Objects/ServiceDataSnapshot.cs
+++ b/PersistentMapAPI/PersistentMapAPI/Objects/ServiceDataSnapshot.cs
@@ -11,7 +11,9 @@ namespace PersistentMapAPI.Objects {
         public int num_connections_inactive = 0;
         public float percent_connections_active = 0.0f;
             
-        public int size_resultHistory = 0;
+        public int num_results = 0;
+        public int num_results_past_inactive_time = 0;
+
         public int size_factionInventory = 0;
         public int size_factionShopsInventory = 0;
 
@@ -27,7 +29,10 @@ namespace PersistentMapAPI.Objects {
             percent_connections_active = size_connectionStore == 0 ? 
                 0.0f : (size_connectionStore - num_connections_inactive) / (size_connectionStore);
 
-            size_resultHistory = Holder.resultHistory.Count;
+            num_results = Holder.resultHistory.Count;
+            num_results_past_inactive_time = Holder.resultHistory
+                .Where(x => x.date < activeOnOrAfter)
+                .Count();
 
         }
     }

--- a/PersistentMapAPI/PersistentMapAPI/Objects/StarMap.cs
+++ b/PersistentMapAPI/PersistentMapAPI/Objects/StarMap.cs
@@ -1,8 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace PersistentMapAPI {
-    public class StarMap {
+    public class StarMap : ICloneable {
+
         public List<System> systems = new List<System>();
 
         public System FindSystemByName(string name) {
@@ -12,5 +14,11 @@ namespace PersistentMapAPI {
             }
             return result;
         }
+
+        // Do a deep clone of all members
+        public object Clone() {
+            return MemberwiseClone();
+        }
+
     }
 }

--- a/PersistentMapAPI/PersistentMapAPI/PersistentMapAPI.csproj
+++ b/PersistentMapAPI/PersistentMapAPI/PersistentMapAPI.csproj
@@ -49,6 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="API\DeprecatedWarServices.cs" />
+    <Compile Include="Objects\ServiceDataSnapshot.cs" />
     <Compile Include="Objects\FactionControl.cs" />
     <Compile Include="Objects\FactionShop.cs" />
     <Compile Include="Util\Helper.cs" />

--- a/PersistentMapAPI/PersistentMapAPI/PersistentMapAPI.csproj
+++ b/PersistentMapAPI/PersistentMapAPI/PersistentMapAPI.csproj
@@ -48,6 +48,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="API\DeprecatedWarServices.cs" />
     <Compile Include="Objects\FactionControl.cs" />
     <Compile Include="Objects\FactionShop.cs" />
     <Compile Include="Util\Helper.cs" />

--- a/PersistentMapAPI/PersistentMapAPI/Util/Helper.cs
+++ b/PersistentMapAPI/PersistentMapAPI/Util/Helper.cs
@@ -18,7 +18,6 @@ namespace PersistentMapAPI {
         public static string settingsFilePath = $"../Settings/settings.json";
         public static string systemDataFilePath = $"../StarSystems/";
 
-
         public static StarMap initializeNewMap() {
             Logger.LogLine("Map Init Started");
             StarMap map = new StarMap();

--- a/PersistentMapAPI/PersistentMapAPI/Util/Holder.cs
+++ b/PersistentMapAPI/PersistentMapAPI/Util/Holder.cs
@@ -4,12 +4,24 @@ using System.Collections.Generic;
 
 namespace PersistentMapAPI {
     public static class Holder {
+        // The current state of the map
         public static StarMap currentMap;
+
         public static Dictionary<string, UserInfo> connectionStore = new Dictionary<string, UserInfo>();
+
+        // All results that have been posted
         public static List<HistoryResult> resultHistory = new List<HistoryResult>();
+        
+        // When the web-service started
         public static DateTime startupTime = DateTime.UtcNow;
+
+        // All of the player contributed items available to a faction
         public static Dictionary<Faction, List<ShopDefItem>> factionInventories;
+
+        // All of the items a faction has for sale
         public static List<FactionShop> factionShops;
+
+        // When the last backup occurred
         public static DateTime lastBackup = DateTime.MinValue;
     }
 }

--- a/PersistentMapAPI/PersistentMapAPI/Util/Holder.cs
+++ b/PersistentMapAPI/PersistentMapAPI/Util/Holder.cs
@@ -7,6 +7,7 @@ namespace PersistentMapAPI {
         // The current state of the map
         public static StarMap currentMap;
 
+        // List of all connections currently tracked
         public static Dictionary<string, UserInfo> connectionStore = new Dictionary<string, UserInfo>();
 
         // All results that have been posted

--- a/PersistentMapServer/PersistentMapServer/HeartBeatMonitor.cs
+++ b/PersistentMapServer/PersistentMapServer/HeartBeatMonitor.cs
@@ -1,4 +1,5 @@
 ﻿using PersistentMapAPI;
+using PersistentMapAPI.Objects;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -35,11 +36,13 @@ namespace PersistentMapServer {
                 // If more than reportTimeSpan was passed since we last logged values, log them
                 DateTime now = DateTime.UtcNow;
                 if (now.Subtract(reportingTimeSpan) > lastReportedTime) {
-                    Logger.LogLine("-------- HeartBeat --------");
-                    Logger.LogLine($"  Calls - Total:({pc_sms_calls.NextValue()}) Outstanding:({pc_sms_callsOutstanding.NextValue()}) " + 
+                    Logger.Debug("-------- HeartBeat --------");
+                    Logger.Debug($"  Calls - Total:({pc_sms_calls.NextValue()}) Outstanding:({pc_sms_callsOutstanding.NextValue()}) " + 
                         $"Faulted:({pc_sms_callsFaulted.NextValue()}) Failed:({pc_sms_callsFailed.NextValue()}) " +
                         $" Max% ({pc_sms_pctMaxCalls.NextValue()})%"
                         );
+                    ServiceDataSnapshot snapshot = new ServiceDataSnapshot();
+                    Logger.Debug($"  ServerDataSnapshot: {snapshot.ToString()}");
                     
                     lastReportedTime = now;
                 }

--- a/PersistentMapServer/PersistentMapServer/HeartBeatMonitor.cs
+++ b/PersistentMapServer/PersistentMapServer/HeartBeatMonitor.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Threading;
 
 namespace PersistentMapServer {
+    /* Reads various performanceCounters that indicate server health, and writes them to the Console */
     class HeartBeatMonitor {
 
         private const string CategoryName_ServiceModelService = "ServiceModelService 4.0.0.0";

--- a/PersistentMapServer/PersistentMapServer/HeartBeatMonitor.cs
+++ b/PersistentMapServer/PersistentMapServer/HeartBeatMonitor.cs
@@ -36,18 +36,18 @@ namespace PersistentMapServer {
                 // If more than reportTimeSpan was passed since we last logged values, log them
                 DateTime now = DateTime.UtcNow;
                 if (now.Subtract(reportingTimeSpan) > lastReportedTime) {
-                    Logger.Debug("-------- HeartBeat --------");
+                    Logger.Debug("  --- HeartBeat ---");
                     Logger.Debug($"  Calls - Total:({pc_sms_calls.NextValue()}) Outstanding:({pc_sms_callsOutstanding.NextValue()}) " + 
                         $"Faulted:({pc_sms_callsFaulted.NextValue()}) Failed:({pc_sms_callsFailed.NextValue()}) " +
                         $" Max% ({pc_sms_pctMaxCalls.NextValue()})%"
                         );
                     ServiceDataSnapshot snapshot = new ServiceDataSnapshot();
-                    Logger.Debug($"  ServerDataSnapshot: {snapshot.ToString()}");
+                    Logger.Debug($"{snapshot.ToString()}");
                     
                     lastReportedTime = now;
                 }
 
-                // Sleep 50ms then check to see if we are cancelled
+                // Sleep a short period to see if we are cancelled.
                 Thread.Sleep(50);
             }                        
         }

--- a/PersistentMapServer/PersistentMapServer/Program.cs
+++ b/PersistentMapServer/PersistentMapServer/Program.cs
@@ -22,9 +22,9 @@ namespace PersistentMapServer {
                 monitor.enable();
 
                 ServiceThrottlingBehavior behaviour = new ServiceThrottlingBehavior();
-                behaviour.MaxConcurrentSessions = 9999;
-                behaviour.MaxConcurrentCalls = 9999;
-                behaviour.MaxConcurrentInstances = 9999;
+                behaviour.MaxConcurrentCalls = 64; // Recommendation is 16 * Processors so 4*16=64
+                behaviour.MaxConcurrentInstances = 1; // Using a singleton instance, so this doens't matter
+                behaviour.MaxConcurrentSessions = 1; // Not using HTTP sessions, so this doesn't matter
 
                 WarServices warServices = new WarServices();
 


### PR DESCRIPTION
Adds concurrency to the system. 
- GETs are fully concurrent
- POSTs are still single threaded. Each unique update type locks independently, so missionResult updates don't block shop updates.
- Added an endpoint to check datasizes
- Added data size monitoring to heartbeat monitoring.