### PR TITLE
Updates to BT 1.7 patch; reset all projects to target .NET 4.7.1

### DIFF
--- a/PersistentMapAPI/PersistentMapAPI/PersistentMapAPI.csproj
+++ b/PersistentMapAPI/PersistentMapAPI/PersistentMapAPI.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PersistentMapAPI</RootNamespace>
     <AssemblyName>PersistentMapAPI</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -29,14 +30,11 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
       <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\BATTLETECH\BattleTech_Data\Managed\Assembly-CSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net35\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -58,9 +56,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config">
-      <SubType>Designer</SubType>
-    </None>
-    <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>

--- a/PersistentMapAPI/PersistentMapAPI/app.config
+++ b/PersistentMapAPI/PersistentMapAPI/app.config
@@ -3,8 +3,8 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
@@ -12,10 +12,10 @@
     <behaviors>
       <endpointBehaviors>
         <behavior name="Website">
-          <webHttp />
+          <webHttp/>
 		  
         </behavior>
       </endpointBehaviors>
     </behaviors>
   </system.serviceModel>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1"/></startup></configuration>

--- a/PersistentMapAPI/PersistentMapAPI/packages.config
+++ b/PersistentMapAPI/PersistentMapAPI/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net35" />
-</packages>

--- a/PersistentMapClient/PersistentMapClient/Patch/PatchWar.cs
+++ b/PersistentMapClient/PersistentMapClient/Patch/PatchWar.cs
@@ -172,7 +172,7 @@ namespace PersistentMapClient {
                     if (__result.Override == null) {
                         PersistentMapClient.Logger.Log(__result.Name + " Does not have an ovveride");
                     }
-                    if (__result.InitialContractValue == null) {
+                    if (__result.InitialContractValue == 0) {
                         PersistentMapClient.Logger.Log(__result.Name + " Does not have an InitialContractValue");
                     }
                     if (__instance.Constants == null) {
@@ -181,13 +181,13 @@ namespace PersistentMapClient {
                     if (__instance.Constants.Salvage == null) {
                         PersistentMapClient.Logger.Log("No Salvage Constants");
                     }
-                    if (__instance.Constants.Salvage.PrioritySalvageModifier == null) {
+                    if (__instance.Constants.Salvage.PrioritySalvageModifier == 0f) {
                         PersistentMapClient.Logger.Log("No PrioritySalvageModifier");
                     }
                     if (Fields.settings == null) {
                         PersistentMapClient.Logger.Log("No Settings");
                     }
-                    if (Fields.settings.priorityContactPayPercentage == null) {
+                    if (Fields.settings.priorityContactPayPercentage == 0f) {
                         PersistentMapClient.Logger.Log("No priorityContactPayPercentage");
                     }
                     __result.SetInitialReward(Mathf.RoundToInt(__result.InitialContractValue * Fields.settings.priorityContactPayPercentage));
@@ -215,13 +215,13 @@ namespace PersistentMapClient {
                         newwidget.transform.SetParent(old.transform.parent, false);
                         newwidget.name = "COMPANYNAMES";
                         old.transform.position = new Vector3(old.transform.position.x, 311, old.transform.position.z);
-                        old.transform.FindRecursive("dotgrid").gameObject.active = false;
-                        old.transform.FindRecursive("crossLL").gameObject.active = false;
+                        old.transform.FindRecursive("dotgrid").gameObject.SetActive(false);
+                        old.transform.FindRecursive("crossLL").gameObject.SetActive(false);
                         newwidget.transform.position = new Vector3(old.transform.position.x, 106, old.transform.position.z);
-                        newwidget.transform.FindRecursive("stats_factionsAndClimate").gameObject.active = false;
-                        newwidget.transform.FindRecursive("owner_icon").gameObject.active = false;
-                        newwidget.transform.FindRecursive("uixPrfIndc_SIM_Reputation-MANAGED").gameObject.active = false;
-                        newwidget.transform.FindRecursive("crossUL").gameObject.active = false;
+                        newwidget.transform.FindRecursive("stats_factionsAndClimate").gameObject.SetActive(false);
+                        newwidget.transform.FindRecursive("owner_icon").gameObject.SetActive(false);
+                        newwidget.transform.FindRecursive("uixPrfIndc_SIM_Reputation-MANAGED").gameObject.SetActive(false);
+                        newwidget.transform.FindRecursive("crossUL").gameObject.SetActive(false);
                         GameObject ownerPanel = newwidget.transform.FindRecursive("owner_detailsPanel").gameObject;
                         ownerPanel.transform.GetComponent<HorizontalLayoutGroup>().childAlignment = TextAnchor.UpperLeft;
                         RectTransform ownerRect = ownerPanel.GetComponent<RectTransform>();

--- a/PersistentMapClient/PersistentMapClient/PersistentMapClient.csproj
+++ b/PersistentMapClient/PersistentMapClient/PersistentMapClient.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PersistentMapClient</RootNamespace>
     <AssemblyName>PersistentMapClient</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -29,18 +30,18 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony, Version=1.2.0.1, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\BATTLETECH\Mods\ModTek\0Harmony.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\..\Steam\steamapps\common\BATTLETECH\Mods\ModTek\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\BATTLETECH\BattleTech_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\..\Steam\steamapps\common\BATTLETECH\BattleTech_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net35\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="PersistentMapAPI">
       <HintPath>..\..\PersistentMapAPI\PersistentMapAPI\bin\Debug\PersistentMapAPI.dll</HintPath>
@@ -51,12 +52,21 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="Unity.TextMeshPro">
+      <HintPath>..\..\..\..\..\..\..\..\Steam\steamapps\common\BATTLETECH\BattleTech_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+    </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\BATTLETECH\BattleTech_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\..\Steam\steamapps\common\BATTLETECH\BattleTech_Data\Managed\UnityEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.CoreModule">
+      <HintPath>..\..\..\..\..\..\..\..\Steam\steamapps\common\BATTLETECH\BattleTech_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.TextRenderingModule">
+      <HintPath>..\..\..\..\..\..\..\..\Steam\steamapps\common\BATTLETECH\BattleTech_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\BATTLETECH\BattleTech_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\..\Steam\steamapps\common\BATTLETECH\BattleTech_Data\Managed\UnityEngine.UI.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/PersistentMapClient/PersistentMapClient/Util/Helper.cs
+++ b/PersistentMapClient/PersistentMapClient/Util/Helper.cs
@@ -458,7 +458,13 @@ namespace PersistentMapClient {
 
             var difficultyRange = AccessTools.Method(typeof(SimGameState), "GetContractRangeDifficultyRange").Invoke(Sim, new object[] { system, Sim.SimGameMode, Sim.GlobalDifficulty });
             Dictionary<ContractType, List<ContractOverride>> potentialContracts = (Dictionary<ContractType, List<ContractOverride>>)AccessTools.Method(typeof(SimGameState), "GetContractOverrides").Invoke(Sim, new object[] { difficultyRange, prioTypes });
-            WeightedList<MapAndEncounters> playableMaps = MetadataDatabase.Instance.GetReleasedMapsAndEncountersByContractTypeAndTagsAndOwnership(potentialContracts.Keys.ToArray<ContractType>(), system.Def.MapRequiredTags, system.Def.MapExcludedTags, system.Def.SupportedBiomes).ToWeightedList(WeightedListType.SimpleRandom);
+            WeightedList<MapAndEncounters> playableMaps =
+                //MetadataDatabase.Instance.GetReleasedMapsAndEncountersByContractTypeAndTagsAndOwnership(potentialContracts.Keys.ToArray<ContractType>(), 
+                //      system.Def.MapRequiredTags, system.Def.MapExcludedTags, system.Def.SupportedBiomes).ToWeightedList(WeightedListType.SimpleRandom);
+                // TODO: MORPH - please review!
+                MetadataDatabase.Instance.GetReleasedMapsAndEncountersBySinglePlayerProceduralContractTypeAndTags(
+                    system.Def.MapRequiredTags, system.Def.MapExcludedTags, system.Def.SupportedBiomes, false)
+                    .ToWeightedList(WeightedListType.SimpleRandom);
             var validParticipants = AccessTools.Method(typeof(SimGameState), "GetValidParticipants").Invoke(Sim, new object[] { system });
             if (!(bool)AccessTools.Method(typeof(SimGameState), "HasValidMaps").Invoke(Sim, new object[] { system, playableMaps })
                 || !(bool)AccessTools.Method(typeof(SimGameState), "HasValidContracts").Invoke(Sim, new object[] { difficultyRange, potentialContracts })

--- a/PersistentMapClient/PersistentMapClient/app.config
+++ b/PersistentMapClient/PersistentMapClient/app.config
@@ -4,8 +4,8 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v2.0.50727" /></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1" /></startup></configuration>

--- a/PersistentMapClient/PersistentMapClient/packages.config
+++ b/PersistentMapClient/PersistentMapClient/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net35" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net471" />
 </packages>

--- a/PersistentMapClient/PersistentMapClientTests/PersistentMapClientTests.csproj
+++ b/PersistentMapClient/PersistentMapClientTests/PersistentMapClientTests.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PersistentMapClientTests</RootNamespace>
     <AssemblyName>PersistentMapClientTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
@@ -22,6 +22,7 @@
     <TestProjectType>UnitTest</TestProjectType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -42,7 +43,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\BATTLETECH\BattleTech_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\..\Steam\steamapps\common\BATTLETECH\BattleTech_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>

--- a/PersistentMapClient/PersistentMapClientTests/app.config
+++ b/PersistentMapClient/PersistentMapClientTests/app.config
@@ -8,4 +8,4 @@
 			</dependentAssembly>
 		</assemblyBinding>
 	</runtime>
-	<startup><supportedRuntime version="v2.0.50727" /></startup></configuration>
+	<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1" /></startup></configuration>

--- a/PersistentMapServer/PersistentMapServer/App.config
+++ b/PersistentMapServer/PersistentMapServer/App.config
@@ -18,7 +18,7 @@
   </system.diagnostics>
   
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1" />
   </startup>
   
   <system.serviceModel>
@@ -31,7 +31,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />

--- a/PersistentMapServer/PersistentMapServer/PersistentMapServer.csproj
+++ b/PersistentMapServer/PersistentMapServer/PersistentMapServer.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PersistentMapServer</RootNamespace>
     <AssemblyName>PersistentMapServer</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />
@@ -38,18 +38,17 @@
   <ItemGroup>
     <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\BATTLETECH\BattleTech_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\..\Steam\steamapps\common\BATTLETECH\BattleTech_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
+      <HintPath>..\packages\Castle.Core.4.4.0\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.5.10\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.6.7\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="PersistentMapAPI">
       <HintPath>..\..\PersistentMapAPI\PersistentMapAPI\bin\Debug\PersistentMapAPI.dll</HintPath>

--- a/PersistentMapServer/PersistentMapServer/packages.config
+++ b/PersistentMapServer/PersistentMapServer/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="4.3.1" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net45" />
-  <package id="NLog" version="4.5.10" targetFramework="net45" />
+  <package id="Castle.Core" version="4.4.0" targetFramework="net471" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net471" />
+  <package id="NLog" version="4.6.7" targetFramework="net471" />
 </packages>


### PR DESCRIPTION
Updates PersistentMap to 1.7. Changes .NET target for all projects to 4.7.1 as per unity 2018.1.

@Morphyum please review the chagnes in Helper.cs:461-468. I've chosen what I think is the correct new method, but I'd like your input.

Otherwise, it was a straightforward update. Note that I've updated nuGet packages as well as the server.